### PR TITLE
upgrade image with compiled healthcheck

### DIFF
--- a/docker/docker-files/Dockerfile
+++ b/docker/docker-files/Dockerfile
@@ -17,7 +17,7 @@ RUN mvn install \
 ###################
 # PACKAGING STAGE #
 ###################
-FROM gisaia/arlas-openjdk-17-distroless:20260413162527
+FROM gisaia/arlas-openjdk-17-distroless:20260414154841
 
 # application placed into /opt/app
 WORKDIR /opt/app

--- a/docker/docker-files/Dockerfile-package-only
+++ b/docker/docker-files/Dockerfile-package-only
@@ -1,7 +1,7 @@
 ###################
 # PACKAGING STAGE #
 ###################
-FROM gisaia/arlas-openjdk-17-distroless:20260413162527
+FROM gisaia/arlas-openjdk-17-distroless:20260414154841
 
 # application placed into /opt/app
 WORKDIR /opt/app


### PR DESCRIPTION
Upgrade to `gisaia/arlas-openjdk-17-distroless:20260414154841` which has a compiled healthcheck
